### PR TITLE
use invariant culture for parsing floats

### DIFF
--- a/NumberManager.Shared/NumberConfig.cs
+++ b/NumberManager.Shared/NumberConfig.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Xml.Serialization;
@@ -228,7 +229,7 @@ namespace NumberManager.Shared
 
             try
             {
-                parts = s.Split(',').Select(f => float.Parse(f)).ToArray();
+                parts = s.Split(',').Select(f => float.Parse(f, CultureInfo.InvariantCulture)).ToArray();
             }
             catch( Exception ex )
             {


### PR DESCRIPTION
Current implementation use system's default culture for parsing floats which breaks the mod on systems with non-English locales (particularly those something other than full stop as a decimal separator, e.g. most of Europe which use comma), i.e. the skins which use emission colours (the only setting in the XML which uses floating-point numbers) are loaded without numbers and sometimes cause (probably) a job reset ("due to recent update"). Logs contain exception like this: `Unhandled Exception: System.FormatException: Input string was not in a correct format.`

It should use the invariant culture to assure the mod loads and works properly on every locale (I've tested it with Russian locale, and it works with no errors in the logs).